### PR TITLE
Update db2stat.pl

### DIFF
--- a/etc/zabbix/scripts/db2stat.pl
+++ b/etc/zabbix/scripts/db2stat.pl
@@ -55,10 +55,16 @@ if ($timeout =~ /^(\d+)$/) {
 
 # Generate stat file name
 my $statfile = "$SNAPSHOT_DIR/$dbname.txt";
+my $tmpstatfile = "$SNAPSHOT_DIR/$dbname.txt.tmp";
 
 # Regenerate stats if file too old
 if (! -f $statfile or (time - (stat($statfile))[10]) > $timeout) {
+  # first touch file to prevent another perform in next moment
+  system("/usr/bin/touch $statfile");
+  #then generate tmp data
   system("db2 get snapshot for database on $dbname >$statfile");
+  #finally swap files
+  system("/usr/bin/cp -p $tmpstatfile $statfile");
 }
 
 # Generate regular expressions to match from args

--- a/etc/zabbix/scripts/db2stat.pl
+++ b/etc/zabbix/scripts/db2stat.pl
@@ -62,7 +62,7 @@ if (! -f $statfile or (time - (stat($statfile))[10]) > $timeout) {
   # first touch file to prevent another perform in next moment
   system("/usr/bin/touch $statfile");
   #then generate tmp data
-  system("db2 get snapshot for database on $dbname >$statfile");
+  system("db2 get snapshot for database on $dbname >$tmpstatfile");
   #finally swap files
   system("/usr/bin/cp -p $tmpstatfile $statfile");
 }


### PR DESCRIPTION
Hello, and please forgive my poor English...

My proposition to update script - update snapshot file time stamp, when getting new snapshot, to prevent to getting an another snapshots, when previous one is running, effects are "periods of empty data in item graphs", because in this moment snapshot file is incomplete, in moment of generation the data text file (getting snapshot) - zabbix agent probably concurrently calls all items monitoring concurrently and calls refresh section of script many times in short moment, and i suppose there instantly overwrites the data snapshot file.