### PR TITLE
Fix for wrong CPU value after container restart

### DIFF
--- a/etc/zabbix/scripts/docker.sh
+++ b/etc/zabbix/scripts/docker.sh
@@ -207,7 +207,7 @@ cpu() {
   else
     OLD_VALUE=$(update_stat $1 "cpuacct.usage" "$NEW_VALUE")
     TIMEDIFF=$(update_stat_time $1 "cpuacct.usage")
-    perl -e "print sprintf(\"%.4f\", (($NEW_VALUE-$OLD_VALUE)/$TIMEDIFF*100))" # nanos to seconds
+    perl -e "print sprintf(\"%.4f\", (($NEW_VALUE-$OLD_VALUE)<0?0:($NEW_VALUE-$OLD_VALUE)/$TIMEDIFF*100))" # cpu percent
   fi
 }
 


### PR DESCRIPTION
Docker CPU meter would show large negative value for single measure after restart due to CPU counter being reset. Fixed by suppressing invalid result and reporting 0 for negative counter difference.