### PR TITLE
IISCRUM-428 discover Windows processes

### DIFF
--- a/custom/conf/process.conf
+++ b/custom/conf/process.conf
@@ -1,0 +1,1 @@
+UserParameter=discover.processes,powershell.exe -NoProfile -ExecutionPolicy bypass -File "C:\zabbix\process.ps1"

--- a/custom/scripts/process.ps1
+++ b/custom/scripts/process.ps1
@@ -1,0 +1,21 @@
+# Zabbix discovery: Find all running processes that can be monitored via Process performance counters
+
+Write-Host -NoNewline '{"data":'
+
+# Find all Counter instances of \Process(*)\% Processor Time set
+# Initial example taken from https://stackoverflow.com/questions/38551504/continuously-monitors-the-cpu-usage-of-top-x-processes
+#
+# We can't just get InstanceName property because in some cases there are multiple performance counters with
+# similar InstanceName properties, however the performenace counter path is different for each of them
+# (eg. Teams, Teams#1, Teams#2 that are all different processes even though InstanceName is Teams for all of them)
+#
+$commands = Get-Counter -Counter "\Process(*)\% Processor Time" -ErrorAction SilentlyContinue |
+  Select-Object -ExpandProperty CounterSamples |
+  where {$_.Status -eq 0 -and $_.instancename -notin "_total", "idle"} |   # Filter out processes we can't access
+  select @{N="{#PROCESS}";E={
+     $_.Path -replace "^.*\\Process\((.*)\)\\% Processor Time$",'$1'
+  }} |
+  ConvertTo-Json -Compress
+Write-Host -NoNewline $commands
+
+Write-Host -NoNewline '}'


### PR DESCRIPTION
I added a note in https://wiki.digia.com/pages/viewpage.action?pageId=127094449 concerning the installation of this script for Windows monitorings in the future.

The idea is to make a similar process monitoring that we already have for Linux that utilizes our process-discovery bash script (https://github.com/digiapulssi/zabbix-monitoring-scripts/blob/master/etc/zabbix/scripts/process.sh) and monitors the processes with proc.* items as follows:
![image](https://user-images.githubusercontent.com/9412499/51464337-ffb1e480-1d6d-11e9-9b88-9ba1cb7671a7.png)

Windows does not support proc.* items. Instead, we need to use perf_count items as follows:
![image](https://user-images.githubusercontent.com/9412499/51464425-325bdd00-1d6e-11e9-887d-9a88bb113777.png)
