### PR TITLE
Kubernetes monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ See the below documentation for each monitoring script.
 
 - [DB2 database snapshot statistics](documentation/db2stat.md)
 - [Docker discovery and monitoring](documentation/docker.md)
+- [Docker Swarm service discovery and monitoring](documentation/docker_swarm.md)
 - [Process discovery and monitoring](documentation/process.md)
 - [Pacemaker monitoring](documentation/pacemaker.md)
 - [PEM file certificate monitoring](documentation/certificates.md)
 - [Kontena grid monitoring](documentation/kontena_grid.md)
+- [Kubernetes monitoring](documentation/kubernetes_monitoring.md)

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -36,12 +36,12 @@ kubectl config view -o jsonpath='{.clusters[0].cluster.server}'
 
 Pull details from existing Kubernetes-configurations:
 ```
-kubectl config set-cluster <cluster_name> --server=<server_address> --certificate-authority=<certificate.crt> --kubeconfig=<config_file> --embed-certs
+kubectl config set-cluster <cluster_name> --server=<server_address> --certificate-authority=<ca.crt> --kubeconfig=<config_file> --embed-certs
 ```
 
 Set up the user:
 ```
-kubectl config set-credentials zabbix --client-certificate=<certificate.crt> --client-key=<private.key> --embed-certs --kubeconfig=<config_file>
+kubectl config set-credentials zabbix --client-certificate=<certificate.crt> --client-key=<private.key> --kubeconfig=<config_file> --embed-certs
 ```
 
 Create a context:
@@ -62,13 +62,15 @@ kubectl label ns <namepace> user=zabbix env=<environment_name>
 
 Specify the context for user zabbix:
 ```
-kubectl config use-context zabbix --kubeconfig=<config_file>
+kubectl config use-context <namespace> --kubeconfig=<config_file>
 ```
 
 Test configurations:
 ```
 kubectl version --kubeconfig=<config_file>
 ```
+
+You should now see a version listing from client and server. Next step is to give access for user to list pods, nodes and services from Kubernetes cluster.
 
 
 ## Usage

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -11,9 +11,64 @@ pip install kubernetes
 ```
 
 
-The zabbix user must have enough privileges to read Kubernetes configuration.
+## Configuring access for user zabbix
 
-* Add read permission for user "zabbix" to directory "${HOME}/.kube/config" and to the certificates it contains.
+The zabbix user must have enough privileges to read Kubernetes configurations
+and access the Kubernetes objects. It is recommended that you create a context
+that specifies the cluster, the user and the namespace that the monitoring
+script will use when making calls to the API server. To achieve this, you need
+to create a kubeconfig file. A kubekonfig file requires the URL of the API
+server, a cluster CA certificate and credentials in the form of a key and a
+certificate signed by the cluster CA. This documentation does not provive steps
+to create certificates or how to have them accepted by an exiting Kubernetes
+cluster. It is assumed the certificates are generated beforehand and approved
+by the cluster.
+
+Retrieve cluster name:
+```
+kubectl config view -o jsonpath='{.clusters[0].name}'
+```
+
+Retrieve cluster server address:
+```
+kubectl config view -o jsonpath='{.clusters[0].cluster.server}'
+```
+
+Pull details from existing Kubernetes-configurations:
+```
+kubectl config set-cluster <cluster_name> --server=<server_address> --certificate-authority=<certificate.crt> --kubeconfig=<config_file> --embed-certs
+```
+
+Set up the user:
+```
+kubectl config set-credentials zabbix --client-certificate=<certificate.crt> --client-key=<private.key> --embed-certs --kubeconfig=<config_file>
+```
+
+Create a context:
+```
+kubectl config set-context zabbix --cluster=<cluster_name> --namespace=<namespace> --user=zabbix --kubeconfig=<config_file>
+```
+The namespace-parameter defines what name is to be used for the context.
+
+Create a namespace:
+```
+kubectl create ns <namespace>
+```
+
+Set label for namespace:
+```
+kubectl label ns <namepace> user=zabbix env=<environment_name>
+```
+
+Specify the context for user zabbix:
+```
+kubectl config use-context zabbix --kubeconfig=<config_file>
+```
+
+Test configurations:
+```
+kubectl version --kubeconfig=<config_file>
+```
 
 
 ## Usage

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -5,10 +5,9 @@ Requirements:
 - 3rd party libraries for Python: kubernetes.
 
 
-## For Python version 2/3, install dependencies using pip/pip3:
+## For Python, install dependencies using pip:
 ```
 pip install kubernetes
-pip3 install kubernetes
 ```
 
 

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -1,0 +1,37 @@
+# Kubernetes pods and nodes discovery and monitoring
+
+Requirements:
+- Python 2.7.13 or Python 3.6.8
+- Libraries for Python: kubernetes.
+
+
+## For Python version 3, install dependencies using pip3:
+```
+pip3 install kubernetes
+```
+
+
+## For Python version 2, install dependencies using pip:
+```
+pip install kubernetes
+```
+
+
+The zabbix user must have enough privileges to read Kubernetes configuration.
+
+* Add read permission for user "zabbix" to directory "${HOME}/.kube/config" and to the certificates it contains.
+
+
+## Usage
+
+Item Syntax | Description | Units |
+----------- | ----------- | ----- |
+kubernetes.discover.pods | Discover all Kubernetes pods | Provides the following template variables: {#POD}. Also provides service information in an array: namespace, ip. |
+
+
+## Retrieving data from discovery using JSONPath
+
+In this example, service data can be retrieved using JSONPath:
+```
+
+```

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -110,18 +110,7 @@ kubectl config set-credentials zabbix --client-certificate=<certificate.crt> --c
 
 Create a context:
 ```
-kubectl config set-context zabbix --cluster=<cluster_name> --namespace=<namespace> --user=zabbix --kubeconfig=<config_file>
-```
-The namespace-parameter defines what name is to be used for the context.
-
-Create a namespace:
-```
-kubectl create ns <namespace>
-```
-
-Set label for namespace:
-```
-kubectl label ns <namepace> user=zabbix env=<environment_name>
+kubectl config set-context zabbix --cluster=<cluster_name> --namespace=default --user=zabbix --kubeconfig=<config_file>
 ```
 
 Specify the context for user zabbix:
@@ -140,7 +129,14 @@ Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.4", GitCom
 Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"<commit_hash>", GitTreeState:"clean", BuildDate:"2020-03-25T14:50:46Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
 ```
 
+
 ### Authorize user to list pods, nodes and services from Kubernetes cluster.
+
+[There is an example file here](kubernetes_monitoring/access.yml).
+
+```
+kubectl create -f kubernetes_monitoring/access.yml
+```
 
 
 ## Usage

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -2,18 +2,13 @@
 
 Requirements:
 - Python 2.7.13 or Python 3.6.8
-- Libraries for Python: kubernetes.
+- 3rd party libraries for Python: kubernetes.
 
 
-## For Python version 3, install dependencies using pip3:
-```
-pip3 install kubernetes
-```
-
-
-## For Python version 2, install dependencies using pip:
+## For Python version 2/3, install dependencies using pip/pip3:
 ```
 pip install kubernetes
+pip3 install kubernetes
 ```
 
 
@@ -26,12 +21,22 @@ The zabbix user must have enough privileges to read Kubernetes configuration.
 
 Item Syntax | Description | Units |
 ----------- | ----------- | ----- |
-kubernetes.discover.pods | Discover all Kubernetes pods | Provides the following template variables: {#POD}. Also provides service information in an array: namespace, ip. |
+kubernetes.discover.pods | Discover all Kubernetes pods | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count. |
+kubernetes.discover.pods.default | Discover all Kubernetes pods using default field selectors | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count. |
+kubernetes.discover.nodes | Discover all Kubernetes nodes | Provides the following template variables: {#NODE}. Also provides service information in an array: node, machine_id, status, system_uuid. |
+kubernetes.discover.services | Discover all Kubernetes services | Provides the following template variables: {#SERVICE}. Also provides service information in an array: namespace, service, uid. |
 
 
 ## Retrieving data from discovery using JSONPath
 
 In this example, service data can be retrieved using JSONPath:
 ```
+$.data[?(@.pod == "<pod>")].pod
+$.data[?(@.pod == "<pod>")].restart_count
 
+$.data[?(@.node == "<node>")].node
+$.data[?(@.node == "<node>")].status
+
+$.data[?(@.service == "<service>")].service
+$.data[?(@.service == "<service>")].uid
 ```

--- a/documentation/kubernetes_monitoring/access.yml
+++ b/documentation/kubernetes_monitoring/access.yml
@@ -1,10 +1,5 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: zabbix
----
-kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: zabbix-role
 rules:
@@ -16,13 +11,13 @@ rules:
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: zabbix-role
 subjects:
-  - kind: ServiceAccount
+  - kind: User
     name: zabbix
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: zabbix-role
   apiGroup: rbac.authorization.k8s.io

--- a/documentation/kubernetes_monitoring/access.yml
+++ b/documentation/kubernetes_monitoring/access.yml
@@ -4,10 +4,7 @@ metadata:
   name: zabbix-role
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/exec"]
-    verbs: ["get", "list"]
-  - apiGroups: ["extensions", "apps"]
-    resources: ["deployments", "deployments/scale"]
+    resources: ["pods", "nodes", "services"]
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/documentation/kubernetes_monitoring/access.yml
+++ b/documentation/kubernetes_monitoring/access.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zabbix
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: zabbix-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec"]
+    verbs: ["get", "list"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zabbix-role
+subjects:
+  - kind: ServiceAccount
+    name: zabbix
+roleRef:
+  kind: Role
+  name: zabbix-role
+  apiGroup: rbac.authorization.k8s.io

--- a/documentation/kubernetes_monitoring/csr.yml
+++ b/documentation/kubernetes_monitoring/csr.yml
@@ -6,5 +6,6 @@ spec:
   groups:
   - system:authenticated
   request: <base_64_encoded_csr>
+  signerName: kubernetes.io/kube-apiserver-client
   usages:
   - client auth

--- a/documentation/kubernetes_monitoring/csr.yml
+++ b/documentation/kubernetes_monitoring/csr.yml
@@ -1,0 +1,10 @@
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: zabbix
+spec:
+  groups:
+  - system:authenticated
+  request: <base_64_encoded_csr>
+  usages:
+  - client auth

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -105,10 +105,10 @@ elif args.mode == "nodes":
             # and NetworkUnavailable. We are interested only in the main one,
             # "Ready", which describes if the node is healthy and ready to
             # accept pods.
-            status = False
+            status = ""
             for condition in node.status.conditions:
                 if condition.type == "Ready":
-                    status = bool(condition.status)
+                    status = condition.status
 
             # Append information to output list
             output.append({

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+
+"""
+Kubernetes service monitoring
+Version: 1.0
+
+Usage:
+python3 kubernetes_monitoring.py pods
+python3 kubernetes_monitoring.py nodes
+"""
+
+# Python imports
+from argparse import ArgumentParser
+import json
+
+# 3rd party imports
+from kubernetes import client, config
+
+# Declare variables
+modes = ["pods", "nodes"] # Available modes
+
+# Parse command-line arguments
+parser = ArgumentParser(
+    description="Discover or retrieve metrics from Kubernetes pods and nodes."
+)
+parser.add_argument("mode", choices=modes, help="Discovery or metric: " + \
+                    ", ".join(modes))
+
+parser.add_argument("-n", "--namespace",
+                    default="metadata.namespace!=kube-system", type=str,
+                    help="Filter results by namespace.")
+
+parser.add_argument("-s", "--status", default="status.phase=Running", type=str,
+                    help="Filter results by status phase.")
+
+args = parser.parse_args()
+
+# Declare variables
+filters = [] # Filters for pods/nodes listings
+
+# Load kubernetes configuration
+config.load_kube_config()
+
+# Initialize client using environment settings
+v1 = client.CoreV1Api()
+
+# Loop pods and create discovery
+if args.mode == "pods":
+
+    # Append command-line arguments to filters
+    if args.namespace:
+        filters.append(args.namespace),
+    if args.status:
+        filters.append(args.status)
+
+    output = []
+    pods = v1.list_pod_for_all_namespaces(
+        watch=False,
+        field_selector="{},{}".format(
+            args.status,
+            args.namespace
+        )
+    )
+
+    for item in pods.items:
+        output.append({
+            "{#POD}": item.metadata.name,
+            "namespace": item.metadata.namespace,
+            "ip": item.status.pod_ip
+        })
+
+    # Dump discovery
+    discovery = {"data": output}
+    print(json.dumps(discovery))
+
+# Loop nodes and create discovery
+elif args.mode == "nodes":
+    output = []
+    nodes = v1.list_node()
+    for item in nodes.items:
+        output.append({
+            "{#NODE}": item.status.node_info.system_uuid
+        })
+
+    # Dump discovery
+    discovery = {"data": output}
+    print(json.dumps(discovery))

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -12,6 +12,7 @@ python3 kubernetes_monitoring.py nodes
 # Python imports
 from argparse import ArgumentParser
 import json
+import os
 import sys
 
 # 3rd party imports
@@ -28,6 +29,9 @@ parser = ArgumentParser(
 parser.add_argument("mode", choices=modes, help="Discovery or metric: " + \
                     ", ".join(modes))
 
+parser.add_argument("-c", "--config", default="", type=str,
+                    help="Filter results by namespace.")
+
 parser.add_argument("-n", "--namespace",
                     default="metadata.namespace!=kube-system", type=str,
                     help="Filter results by namespace.")
@@ -40,9 +44,18 @@ args = parser.parse_args()
 # Declare variables
 filters = [] # Filters for pods/nodes listings
 
+# Check configuration file
+if args.config != "":
+    if not os.path.isfile(args.config):
+        print("Configuration file is not valid.")
+        sys.exit()
+
 # Load kubernetes configuration
 try:
-    config.load_kube_config()
+    if args.config != "":
+        config.load_kube_config(config_file=args.config)
+    else:
+        config.load_kube_config()
 except Exception as e:
     print("Unable to load Kubernetes configurations. Error: {}".format(e))
     sys.exit()

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -125,21 +125,24 @@ if __name__ == "__main__":
     output = [] # List for output data
 
     # Parse command-line arguments
-    parser = ArgumentParser(
-        description="Discover and retrieve metrics from Kubernetes.",
-        add_help=False
-    )
-    subparsers = parser.add_subparsers()
-    parser.add_argument("-c", "--config", default="", dest="config", type=str,
+    top_parser = ArgumentParser(add_help=False)
+    top_parser.add_argument("-c", "--config", default="", dest="config",
+                        type=str,
                         help="Configuration file for Kubernetes client.")
-    parser.add_argument("-f", "--field-selector", default="",
+    top_parser.add_argument("-f", "--field-selector", default="",
                         dest="field_selector", type=str,
                         help="Filter results using field selectors.")
-    parser_pods = subparsers.add_parser("pods", parents=[parser])
+    parser = ArgumentParser(
+        description="Discover and retrieve metrics from Kubernetes.",
+        add_help=False,
+        parents=[top_parser]
+    )
+    subparsers = parser.add_subparsers()
+    parser_pods = subparsers.add_parser("pods", parents=[top_parser])
     parser_pods.set_defaults(func=pods)
-    parser_nodes = subparsers.add_parser("nodes", parents=[parser])
+    parser_nodes = subparsers.add_parser("nodes", parents=[top_parser])
     parser_nodes.set_defaults(func=nodes)
-    parser_services = subparsers.add_parser("services", parents=[parser])
+    parser_services = subparsers.add_parser("services", parents=[top_parser])
     parser_services.set_defaults(func=services)
     args = parser.parse_args()
 
@@ -152,6 +155,7 @@ if __name__ == "__main__":
     # Load kubernetes configuration
     try:
         if args.config != "":
+            print("DING DING DING:", args.config)
             config.load_kube_config(config_file=args.config)
         else:
             config.load_kube_config()

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -125,25 +125,28 @@ if __name__ == "__main__":
     output = [] # List for output data
 
     # Parse command-line arguments
-    common_parser = ArgumentParser(add_help=False)
-    common_parser.add_argument("-c", "--config", default="", dest="config",
-                        type=str,
-                        help="Configuration file for Kubernetes client.")
-    common_parser.add_argument("-f", "--field-selector", default="",
-                        dest="field_selector", type=str,
-                        help="Filter results using field selectors.")
     parser = ArgumentParser(
         description="Discover and retrieve metrics from Kubernetes.",
-        add_help=False,
-        parents=[common_parser]
     )
+
+    # Use sub-parsers run functions using mandatory positional argument
     subparsers = parser.add_subparsers()
-    parser_pods = subparsers.add_parser("pods", parents=[common_parser])
+    parser_pods = subparsers.add_parser("pods")
     parser_pods.set_defaults(func=pods)
-    parser_nodes = subparsers.add_parser("nodes", parents=[common_parser])
-    parser_nodes.set_defaults(func=nodes)
-    parser_services = subparsers.add_parser("services", parents=[common_parser])
+    parser_services = subparsers.add_parser("services")
     parser_services.set_defaults(func=services)
+    parser_nodes = subparsers.add_parser("nodes")
+    parser_nodes.set_defaults(func=nodes)
+
+    # Each subparser has the same optional arguments. For now.
+    for item in [parser_pods, parser_nodes, parser_services]:
+        item.add_argument("-c", "--config", default="", dest="config",
+                            type=str,
+                            help="Configuration file for Kubernetes client.")
+        item.add_argument("-f", "--field-selector", default="",
+                            dest="field_selector", type=str,
+                            help="Filter results using field selectors.")
+
     args = parser.parse_args()
 
     # Check configuration file

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -69,17 +69,14 @@ if args.mode == "pods":
         for pod in pods.items:
 
             # Retrieve container's restart counts
-            restart_count = []
+            restart_count = 0
             for container in pod.status.container_statuses:
-                restart_count.append("{}: {}".format(
-                    container.name,
-                    container.restart_count
-                ))
+                restart_count += int(container.restart_count)
 
             # Append information to output list
             output.append({
                 "{#POD}": pod.metadata.name,
-                "restart_count": ", ".join(restart_count),
+                "restart_count": restart_count,
                 "ip": pod.status.pod_ip,
                 "namespace": pod.metadata.namespace,
                 "pod": pod.metadata.name

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -112,8 +112,6 @@ def services(args, client):
 if __name__ == "__main__":
 
     # Declare variables
-    field_selector = "" # Field selector filter for results.
-    modes = ["pods", "nodes", "services"] # Available modes
     output = [] # List for output data
 
     # Parse command-line arguments

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -5,10 +5,10 @@ Kubernetes monitoring
 Version: 1.0
 
 Usage:
-python3 kubernetes_monitoring.py pods
-python3 kubernetes_monitoring.py pods -c <config_file> -f <field_selector>
-python3 kubernetes_monitoring.py nodes
-python3 kubernetes_monitoring.py services
+python kubernetes_monitoring.py pods
+python kubernetes_monitoring.py pods -c <config_file> -f <field_selector>
+python kubernetes_monitoring.py nodes
+python kubernetes_monitoring.py services
 """
 
 # Python imports

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -125,24 +125,24 @@ if __name__ == "__main__":
     output = [] # List for output data
 
     # Parse command-line arguments
-    top_parser = ArgumentParser(add_help=False)
-    top_parser.add_argument("-c", "--config", default="", dest="config",
+    common_parser = ArgumentParser(add_help=False)
+    common_parser.add_argument("-c", "--config", default="", dest="config",
                         type=str,
                         help="Configuration file for Kubernetes client.")
-    top_parser.add_argument("-f", "--field-selector", default="",
+    common_parser.add_argument("-f", "--field-selector", default="",
                         dest="field_selector", type=str,
                         help="Filter results using field selectors.")
     parser = ArgumentParser(
         description="Discover and retrieve metrics from Kubernetes.",
         add_help=False,
-        parents=[top_parser]
+        parents=[common_parser]
     )
     subparsers = parser.add_subparsers()
-    parser_pods = subparsers.add_parser("pods", parents=[top_parser])
+    parser_pods = subparsers.add_parser("pods", parents=[common_parser])
     parser_pods.set_defaults(func=pods)
-    parser_nodes = subparsers.add_parser("nodes", parents=[top_parser])
+    parser_nodes = subparsers.add_parser("nodes", parents=[common_parser])
     parser_nodes.set_defaults(func=nodes)
-    parser_services = subparsers.add_parser("services", parents=[top_parser])
+    parser_services = subparsers.add_parser("services", parents=[common_parser])
     parser_services.set_defaults(func=services)
     args = parser.parse_args()
 
@@ -155,7 +155,6 @@ if __name__ == "__main__":
     # Load kubernetes configuration
     try:
         if args.config != "":
-            print("DING DING DING:", args.config)
             config.load_kube_config(config_file=args.config)
         else:
             config.load_kube_config()

--- a/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
+++ b/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
@@ -2,5 +2,6 @@ UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitor
 UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes" --config "$1" --field-selector "$2"
 UserParameter=kubernetes.discover.services[*],/etc/zabbix/scripts/kubernetes_monitoring.py "services" --config "$1" --field-selector "$2"
 
-# Metric retrievals for Zabbix 4.0 compatibility. Use dependent discoveries on Zabbix 4.2+
-UserParameter=kubernetes.pod.restart.count[*],/etc/zabbix/scripts/kubernetes_monitoring.py "restart_count" --config "$1" --field-selector "$2"
+# Default field selectors for pods.
+# Possible status phase values are: Pending, Running, Succeeded, Failed or Unknown.
+UserParameter=kubernetes.discover.pods.default[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --field-selector "metadata.namespace!=kube-system,status.phase=Running"

--- a/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
+++ b/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
@@ -1,0 +1,3 @@
+UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods"
+UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes"
+

--- a/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
+++ b/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
@@ -1,3 +1,4 @@
 UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods"
+UserParameter=kubernetes.discover.pods.namespace[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --namespace "$1"
+UserParameter=kubernetes.discover.pods.status[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --status "$1"
 UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes"
-

--- a/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
+++ b/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
@@ -1,4 +1,4 @@
-UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods"
-UserParameter=kubernetes.discover.pods.namespace[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --namespace "$1"
-UserParameter=kubernetes.discover.pods.status[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --status "$1"
-UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes"
+UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1"
+UserParameter=kubernetes.discover.pods.namespace[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --namespace "$2"
+UserParameter=kubernetes.discover.pods.status[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --status "$2"
+UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes" --config "$1"

--- a/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
+++ b/etc/zabbix/zabbix_agentd.d/kubernetes_monitoring.conf
@@ -1,4 +1,6 @@
-UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1"
-UserParameter=kubernetes.discover.pods.namespace[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --namespace "$2"
-UserParameter=kubernetes.discover.pods.status[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --status "$2"
-UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes" --config "$1"
+UserParameter=kubernetes.discover.pods[*],/etc/zabbix/scripts/kubernetes_monitoring.py "pods" --config "$1" --field-selector "$2"
+UserParameter=kubernetes.discover.nodes[*],/etc/zabbix/scripts/kubernetes_monitoring.py "nodes" --config "$1" --field-selector "$2"
+UserParameter=kubernetes.discover.services[*],/etc/zabbix/scripts/kubernetes_monitoring.py "services" --config "$1" --field-selector "$2"
+
+# Metric retrievals for Zabbix 4.0 compatibility. Use dependent discoveries on Zabbix 4.2+
+UserParameter=kubernetes.pod.restart.count[*],/etc/zabbix/scripts/kubernetes_monitoring.py "restart_count" --config "$1" --field-selector "$2"


### PR DESCRIPTION
The description said that we need pod restart count, but you cannot get the same information from the Python API the same way. Only the containers inside the pods have that information. Using `kubectl get pods` command you get a listing where there is a column titled _restarts_. It is the same count you get while running `kubectl describe pod <pod>`. So my approach was simply to retrieve the restart_count from the containers as a comma separated string and container name. This is probably not what we want though, so feel free to guide me so I can make this better. Debugging restart count is somewhat described here:
https://kubernetes.io/docs/tasks/debug-application-cluster/

Python API link for V1ContainerStatus and it's restart_count: https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1ContainerStatus.md

There Node status is retrieved from node's conditions. There are several node conditions and I believe we only want the "Ready" condition, which describes if the node is healthy and ready to accept pods. A link to the documentation:
https://kubernetes.io/docs/concepts/architecture/nodes/#node-status

Service discovery was not included in the description of the ticket, but I chose to include it because why not. Just say the word and I'll remove it if it's unnecessary.