### PR TITLE
Kubernetes monitoring 2

### DIFF
--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -24,7 +24,9 @@ certificate signed by the cluster CA.
 This documentation provides steps to create certificates and how to have them
 accepted by an existing Kubernetes cluster. If you already have existing
 certificates and configurations, you may skip the first part where certificates
-are created and approved.
+are created and approved. There is a template for the configuration file in case
+you already have the certificates and you do not have a configuration file:
+[There is an example file here](kubernetes_monitoring/config).
 
 ### Creating a certificate signing request (CSR) and retrieving certificates
 

--- a/documentation/kubernetes_monitoring.md
+++ b/documentation/kubernetes_monitoring.md
@@ -145,8 +145,8 @@ kubectl create -f kubernetes_monitoring/access.yml
 
 Item Syntax | Description | Units |
 ----------- | ----------- | ----- |
-kubernetes.discover.pods | Discover all Kubernetes pods | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count. |
-kubernetes.discover.pods.default | Discover all Kubernetes pods using default field selectors | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count. |
+kubernetes.discover.pods | Discover all Kubernetes pods | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count, uptime. |
+kubernetes.discover.pods.default | Discover all Kubernetes pods using default field selectors | Provides the following template variables: {#POD}. Also provides service information in an array: ip, namespace, pod, restart_count, uptime. |
 kubernetes.discover.nodes | Discover all Kubernetes nodes | Provides the following template variables: {#NODE}. Also provides service information in an array: node, machine_id, status, system_uuid. |
 kubernetes.discover.services | Discover all Kubernetes services | Provides the following template variables: {#SERVICE}. Also provides service information in an array: namespace, service, uid. |
 

--- a/documentation/kubernetes_monitoring/config
+++ b/documentation/kubernetes_monitoring/config
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: /path/to/ca.crt
+    server: https://127.0.0.1:8443
+  name: <cluster_name>
+contexts:
+- context:
+    cluster: <cluster_name>
+    user: <user_name>
+  name: <context_name>
+current-context: <context_name>
+kind: Config
+preferences: {}
+users:
+- name: <user_name>
+  user:
+    client-certificate: /path/to/client.crt
+    client-key: /path/to/client.key

--- a/etc/zabbix/scripts/kubernetes_monitoring.py
+++ b/etc/zabbix/scripts/kubernetes_monitoring.py
@@ -31,8 +31,6 @@ from kubernetes import client, config
 # Loop pods and create discovery
 def pods(args, v1):
 
-    # Retrieve system time for uptime calculation
-
     pods = v1.list_pod_for_all_namespaces(
         watch=False,
         field_selector=args.field_selector


### PR DESCRIPTION
The "started_at"-date was changed to "uptime"-metric as discussed with @kompa3. Same metric as in Docker Swarm monitoring has. I could not find a field for system time in Kubernetes API, so I used the system time that Python returns. I hope we can discuss this further on this pull request, since we got the system time from Docker API.