### PR TITLE
Python 3 compatibility

### DIFF
--- a/etc/zabbix/scripts/check_certificate.py
+++ b/etc/zabbix/scripts/check_certificate.py
@@ -18,16 +18,16 @@ def format_x509_name(x509_name):
     name = ""
     for c in x509_name.get_components():
         name += '/'
-        name += c[0]
+        name += c[0].decode("utf-8")
         name += '='
-        name += c[1]
+        name += c[1].decode("utf-8")
     return name
 
 
 def from_asn1_date(asn1date):
     """Converts ASN1 formatted datetime into datetime object.
     """
-    return datetime.strptime(asn1date, '%Y%m%d%H%M%SZ')
+    return datetime.strptime(asn1date.decode("utf-8"), '%Y%m%d%H%M%SZ')
 
 
 def get_certificate(file_name, index):

--- a/etc/zabbix/scripts/discover_certificates.py
+++ b/etc/zabbix/scripts/discover_certificates.py
@@ -42,9 +42,9 @@ def format_x509_name(x509_name):
     name = ""
     for c in x509_name.get_components():
         name += '/'
-        name += c[0]
+        name += c[0].decode("utf-8")
         name += '='
-        name += c[1]
+        name += c[1].decode("utf-8")
     return name
 
 

--- a/etc/zabbix/scripts/pacemaker.py
+++ b/etc/zabbix/scripts/pacemaker.py
@@ -41,7 +41,7 @@ def process_xml():
 	process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 	xml, error = process.communicate()
 	if error:
-		print("Could not read command output:" + error)
+		print("Could not read command output: " + error.decode("utf-8"))
 		exit()
 	try:
 		root = etree.fromstring(xml)

--- a/etc/zabbix/scripts/pacemaker.py
+++ b/etc/zabbix/scripts/pacemaker.py
@@ -45,7 +45,7 @@ def process_xml():
 		exit()
 	try:
 		root = etree.fromstring(xml)
-	except Exception, e:
+	except Exception as e:
 		if ("Connection to cluster failed: Transport endpoint is not connected" in xml):
 			# cluster is not running, all queries default to 0
 			print("0")


### PR DESCRIPTION
Building Zabbix Agent for CentOS 8 revealed that the rpm building process checks Python scripts so there is a valid shebang line which defines which Python version the script should be run on. I added the shebang lines to these scripts in commit ec276dc5281ed013594d488b077105a1b8f66d34. Now I tested these scripts so that they are compatible using Python 3. I would like to include these changes to our newest Zabbix Agent build.