### PR TITLE
Iiscrum 1560

### DIFF
--- a/etc/zabbix/scripts/rsync_logs.sh
+++ b/etc/zabbix/scripts/rsync_logs.sh
@@ -2,15 +2,17 @@
 
 # Transfer AIX application logs to proxy server via rsync
 
-SOURCEFILE=$1
-DESTINATIONPATH=$2
-DESTINATIONSERVER=$3
-RSYNCVARS=$4
+set -e
+
+SOURCEFILE="$1"
+DESTINATIONPATH="$2"
+DESTINATIONSERVER="$3"
+RSYNCVARS="$4"
 
 # Check that rsync variables file exists and create one if not
 if [ ! -f "$RSYNCVARS" ]; then
   touch "$RSYNCVARS"
-  cat > $RSYNCVARS << EOL
+  cat > "$RSYNCVARS" << EOL
   PREVSIZE=0
   INODE=0
 EOL
@@ -28,19 +30,23 @@ LOGFILESIZE=$(wc -c "$SOURCEFILE" | awk '{print $1}')
 if [ $NEWINODE -eq $INODE ]; then
 
   if [ $LOGFILESIZE -gt $PREVSIZE ]; then
-    rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SOURCEFILE rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+    rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$SOURCEFILE" rsync@$DESTINATIONSERVER:"$DESTINATIONPATH"
   else
-    rsync -za -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SOURCEFILE rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+    rsync -za -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$SOURCEFILE" rsync@$DESTINATIONSERVER:"$DESTINATIONPATH"
   fi
 else
   # If the logfile has just rotated, find the rotated version and transfer remaining logs
-  OLDLOGFILEPATH=$(dirname "$SOURCEFILE")
-  OLDLOGFILEPATH=$(find "$OLDLOGFILEPATH" -inum "$INODE")
-  rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $OLDLOGFILEPATH rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+  if [ ! $INODE -eq "0" ]; then
+    OLDLOGFILEPATH=$(dirname "$SOURCEFILE")
+    OLDLOGFILEPATH=$(find "$OLDLOGFILEPATH" -inum "$INODE" 2>/dev/null || true)
+    if [ ! -z "$OLDLOGFILEPATH" ]; then
+      rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" "$OLDLOGFILEPATH" rsync@$DESTINATIONSERVER:"$DESTINATIONPATH"
+    fi
+  fi
 fi
 
 # Set variables in helper file
-cat > $RSYNCVARS << EOL
+cat > "$RSYNCVARS" << EOL
 PREVSIZE=${LOGFILESIZE}
 INODE=${NEWINODE}
 EOL

--- a/etc/zabbix/scripts/rsync_logs.sh
+++ b/etc/zabbix/scripts/rsync_logs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Transfer AIX application logs to proxy server via rsync
+
+SOURCEFILE=$1
+DESTINATIONPATH=$2
+DESTINATIONSERVER=$3
+RSYNCVARS=$4
+
+# Check that rsync variables file exists and create one if not
+if [ ! -f "$RSYNCVARS" ]; then
+  touch "$RSYNCVARS"
+  cat > $RSYNCVARS << EOL
+  PREVSIZE=0
+  INODE=0
+EOL
+fi
+
+source "$RSYNCVARS"
+
+# Check the inode of logfile
+NEWINODE=$(ls -i "$SOURCEFILE" | awk '{print $1}')
+
+# Check the size of logfile
+LOGFILESIZE=$(wc -c "$SOURCEFILE" | awk '{print $1}')
+
+# If the logfile is same as before
+if [ $NEWINODE -eq $INODE ]; then
+
+  if [ $LOGFILESIZE -gt $PREVSIZE ]; then
+    rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SOURCEFILE rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+  else
+    rsync -za -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SOURCEFILE rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+  fi
+else
+  # If the logfile has just rotated, find the rotated version and transfer remaining logs
+  OLDLOGFILEPATH=$(dirname "$SOURCEFILE")
+  OLDLOGFILEPATH=$(find "$OLDLOGFILEPATH" -inum "$INODE")
+  rsync -za --append -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $OLDLOGFILEPATH rsync@$DESTINATIONSERVER:$DESTINATIONPATH
+fi
+
+# Set variables in helper file
+cat > $RSYNCVARS << EOL
+PREVSIZE=${LOGFILESIZE}
+INODE=${NEWINODE}
+EOL

--- a/etc/zabbix/zabbix_agentd/rsync_logs.conf
+++ b/etc/zabbix/zabbix_agentd/rsync_logs.conf
@@ -1,0 +1,6 @@
+UserParameter=rsync.logs[*],/opt/freeware/zabbix/conf/scripts/rsync_logs.sh "$1" "$2" "$3" "$4"
+
+# First parameter: Path of logfile which is going to be read
+# Second parameter: Destination file on proxyserver where logfile contents are transferred 
+# Third parameter Ip address of destination server where logfile contents are transferred
+# Fourth parameter: Path of rsync helper file (where variables are stored) on source server


### PR DESCRIPTION
The rotated logfile is located by the inode of the file. But the inode is unique only per filesystem. When search from entire disk, there may be multiple results with same inode number. Therefore current implementation assumes that rotated logfile is in the same folder as active logfile.